### PR TITLE
Add health status publisher for Redis with configurable interval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "petal-app-manager"
-version = "0.1.34"
+version = "0.1.35"
 description = "A FastAPI interface for loading, managing and running Droneleaf Petal applications"
 authors = [
     {name = "Khalil Al Handawi", email = "khalil.alhandawi@droneleaf.io"},

--- a/src/petal_app_manager/__init__.py
+++ b/src/petal_app_manager/__init__.py
@@ -53,6 +53,7 @@ class Config:
         DB = int(os.environ.get('REDIS_DB', 0))
         PASSWORD = os.environ.get('REDIS_PASSWORD', None)
         UNIX_SOCKET_PATH = os.environ.get('REDIS_UNIX_SOCKET_PATH', None)
+        HEALTH_MESSAGE_RATE = float(os.environ.get('REDIS_HEALTH_MESSAGE_RATE', 3.0))
 
     # URLs for data operations
     GET_DATA_URL    = os.environ.get('GET_DATA_URL', '/drone/onBoard/config/getData')
@@ -98,6 +99,7 @@ class Config:
     REDIS_DB = RedisConfig.DB
     REDIS_PASSWORD = RedisConfig.PASSWORD
     REDIS_UNIX_SOCKET_PATH = RedisConfig.UNIX_SOCKET_PATH
+    REDIS_HEALTH_MESSAGE_RATE = RedisConfig.HEALTH_MESSAGE_RATE
 
     TS_CLIENT_HOST = MQTTConfig.TS_CLIENT_HOST
     TS_CLIENT_PORT = MQTTConfig.TS_CLIENT_PORT


### PR DESCRIPTION
This pull request introduces a new background health status publisher to the Petal App Manager. The publisher periodically gathers detailed health information from core services and proxies, formats it, and publishes it to a Redis channel for real-time monitoring. The health publishing interval is now configurable via environment variables, and the publisher is gracefully started and stopped during application startup and shutdown.

**Health Status Publisher Integration**
* Added a background async task (`publish_health_status`) that periodically collects health data and publishes a formatted status message to the `/controller-dashboard/petals-status` Redis channel. The health message includes overall status and detailed info for Organization Manager and all configured proxies.
* The health publishing interval is configurable via the new `REDIS_HEALTH_MESSAGE_RATE` environment variable, with corresponding configuration updates in `RedisConfig` and `LoggingConfig`. [[1]](diffhunk://#diff-fe78c15b7b87f9827bde531d8193a30070d681f843be8a078826f689dc0422d5R56) [[2]](diffhunk://#diff-fe78c15b7b87f9827bde531d8193a30070d681f843be8a078826f689dc0422d5R102)

**Application Lifecycle Management**
* The health publisher task is started during application startup if the Redis proxy is available, and is cleanly cancelled during shutdown to ensure no background tasks are left running. [[1]](diffhunk://#diff-4ecd7d29b755c71154de7298ef2ff1ed1abbc0b8d2838fd64c47b130f4db8f1eL224-R396) [[2]](diffhunk://#diff-4ecd7d29b755c71154de7298ef2ff1ed1abbc0b8d2838fd64c47b130f4db8f1eL261-R455)

**Supporting Changes**
* Added necessary imports for time and datetime to support health message formatting.
* Incremented the application version in `pyproject.toml` to `0.1.35` to reflect the new feature.