### PR TITLE
Fix/petal version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "petal-app-manager"
-version = "0.1.37"
+version = "0.1.38"
 description = "A FastAPI interface for loading, managing and running Droneleaf Petal applications"
 authors = [
     {name = "Khalil Al Handawi", email = "khalil.alhandawi@droneleaf.io"},


### PR DESCRIPTION
This pull request updates the version of the `petal-app-manager` package and modifies a production dependency in the `pyproject.toml` file.

Dependency updates:

* Bumped the package version from `0.1.37` to `0.1.38` in `pyproject.toml` to reflect the new release.
* Downgraded the `petal-user-journey-coordinator` dependency from version `0.1.12` to `0.1.2` in the production dependencies list in `pyproject.toml`.