### PR TITLE
chore: Bump version to 0.1.40 and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "petal-app-manager"
-version = "0.1.39"
+version = "0.1.40"
 description = "A FastAPI interface for loading, managing and running Droneleaf Petal applications"
 authors = [
     {name = "Khalil Al Handawi", email = "khalil.alhandawi@droneleaf.io"},
@@ -32,13 +32,13 @@ cicd = [
     "pytest-asyncio>=1.0.0",
     "anyio>=4.9.0",
     "pytest-cov>=6.2.1",
-    "leaf-pymavlink>=0.1.7",
+    "leaf-pymavlink>=0.1.11",
 ]
 prod = [
-    "leaf-pymavlink>=0.1.7",
+    "leaf-pymavlink>=0.1.11",
     "petal-flight-log @ git+https://github.com/DroneLeaf/petal-flight-log.git@v0.1.6",
     "petal-warehouse @ git+https://github.com/DroneLeaf/petal-warehouse.git@v0.1.7",
-    "petal-leafsdk @ git+https://github.com/DroneLeaf/petal-leafsdk.git@v0.1.12",
+    "petal-leafsdk @ git+https://github.com/DroneLeaf/petal-leafsdk.git@v0.2.0",
     "petal-user-journey-coordinator @ git+https://github.com/DroneLeaf/petal-user-journey-coordinator.git@v0.1.2",
 ]
 dev = [


### PR DESCRIPTION
This pull request updates the `pyproject.toml` file to bump the project version and update several dependencies to their latest versions. These changes ensure compatibility with newer releases and may include important bug fixes or features from upstream packages.

Dependency updates:

* Updated `leaf-pymavlink` to version `0.1.11` in both `cicd` and `prod` dependency groups to use the latest release.
* Updated `petal-leafsdk` to version `0.2.0` in the `prod` dependency group for improved features and compatibility.

Project metadata:

* Bumped the project version from `0.1.39` to `0.1.40` to reflect these changes.