### PR TITLE
Fix/reboot px4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "petal-app-manager"
-version = "0.2.3"
+version = "0.2.4"
 description = "A FastAPI interface for loading, managing and running Droneleaf Petal applications"
 authors = [
     {name = "Khalil Al Handawi", email = "khalil.alhandawi@droneleaf.io"},

--- a/src/petal_app_manager/__init__.py
+++ b/src/petal_app_manager/__init__.py
@@ -83,6 +83,7 @@ class Config:
         TEST_TOPIC = os.environ.get('PETAL_TEST_TOPIC', 'command')
         COMMAND_WEB_TOPIC = os.environ.get('PETAL_COMMAND_WEB_TOPIC', 'command/web')
         HEALTH_CHECK_INTERVAL = float(os.environ.get('PETAL_MQTT_HEALTH_CHECK_INTERVAL', 10.0))
+        HEALTH_PROBE_TIMEOUT_S = float(os.environ.get('PETAL_MQTT_HEALTH_PROBE_TIMEOUT', 2.0))
     # Misc
     class PetalUserJourneyCoordinatorConfig:
         DEBUG_SQUARE_TEST = os.environ.get("PETAL_DEBUG_SQUARE_TEST", "false").lower() in ("true", "1", "yes")
@@ -155,6 +156,7 @@ class Config:
     TEST_TOPIC = MQTTConfig.TEST_TOPIC
     COMMAND_WEB_TOPIC = MQTTConfig.COMMAND_WEB_TOPIC
     MQTT_HEALTH_CHECK_INTERVAL = MQTTConfig.HEALTH_CHECK_INTERVAL
+    MQTT_HEALTH_PROBE_TIMEOUT_S = MQTTConfig.HEALTH_PROBE_TIMEOUT_S
 
     MQTT_RETRY_INTERVAL = ProxyConfig.MQTT_RETRY_INTERVAL
     CLOUD_RETRY_INTERVAL = ProxyConfig.CLOUD_RETRY_INTERVAL

--- a/src/petal_app_manager/health_service.py
+++ b/src/petal_app_manager/health_service.py
@@ -871,9 +871,36 @@ class HealthService:
     async def _check_mqtt_proxy(self, proxy: MQTTProxy) -> MqttProxyHealth:
         """Check MQTT proxy health."""
         try:
-            # Use the proxy's built-in health check method
-            health_status = await proxy.health_check()
-            
+            # Bound the probe by the publish interval so a slow MQTT
+            # health call (which goes through the single MQTTProxy executor
+            # shared with subscribe/publish RPCs) cannot stall the health
+            # publisher loop. Mirrors the S3 probe's protection above.
+            mqtt_probe_timeout = self._probe_timeout()
+            try:
+                health_status = await asyncio.wait_for(
+                    proxy.health_check(),
+                    timeout=mqtt_probe_timeout,
+                )
+            except asyncio.TimeoutError:
+                self.logger.warning(
+                    "MQTT health_check timed out after %.2fs "
+                    "(kept below health publish interval to avoid overlap)",
+                    mqtt_probe_timeout,
+                )
+                return MqttProxyHealth(
+                    status="unhealthy",
+                    details=(
+                        f"MQTT health_check timed out after "
+                        f"{mqtt_probe_timeout:.2f}s"
+                    ),
+                    connection={
+                        "ts_client": False,
+                        "callback_server": False,
+                        "connected": False,
+                    },
+                    error="timeout",
+                )
+
             if health_status.get("status") == "healthy":
                 return MqttProxyHealth(
                     status="healthy",

--- a/src/petal_app_manager/health_service.py
+++ b/src/petal_app_manager/health_service.py
@@ -2,6 +2,7 @@
 Unified health check service that eliminates duplication between HTTP endpoints and Redis publishing.
 """
 
+import asyncio
 import time
 import logging
 from datetime import datetime
@@ -41,10 +42,47 @@ class HealthService:
     Unified health service that provides consistent health checking functionality
     for both HTTP endpoints and Redis publishing.
     """
-    
-    def __init__(self, logger: Optional[logging.Logger] = None):
-        """Initialize the health service with optional logger."""
+
+    # Default publish interval used to derive per-probe timeouts when no
+    # Config is supplied. Kept in sync with RedisConfig.HEALTH_MESSAGE_RATE.
+    _DEFAULT_HEALTH_MESSAGE_RATE = 3.0
+
+    def __init__(
+        self,
+        logger: Optional[logging.Logger] = None,
+        config: Optional[Any] = None,
+    ):
+        """Initialize the health service.
+
+        Args:
+            logger: Optional logger instance.
+            config: Application Config (class or instance) exposing
+                ``REDIS_HEALTH_MESSAGE_RATE``. Used to bound per-proxy health
+                probe timeouts so a single probe cannot overlap into the
+                next health publisher iteration.
+        """
         self.logger = logger or logging.getLogger(__name__)
+        self.config = config
+
+    @property
+    def health_publish_interval(self) -> float:
+        """Configured health publish interval in seconds."""
+        if self.config is not None:
+            rate = getattr(self.config, "REDIS_HEALTH_MESSAGE_RATE", None)
+            if rate is not None:
+                try:
+                    return float(rate)
+                except (TypeError, ValueError):
+                    pass
+        return self._DEFAULT_HEALTH_MESSAGE_RATE
+
+    def _probe_timeout(self, margin: float = 0.5, floor: float = 0.5) -> float:
+        """Compute a per-probe timeout strictly below the publish interval.
+
+        Ensures a slow proxy probe cannot overlap into the next iteration of
+        the health publisher loop.
+        """
+        return max(floor, self.health_publish_interval - margin)
     
     async def get_detailed_health_status(self, proxies_dict: Dict[str, Any]) -> DetailedHealthResponse:
         """
@@ -717,17 +755,32 @@ class HealthService:
                 s3_test = None
                 try:
                     if proxy.s3_client:
-                        # Try to list a few objects to test S3 connectivity
-                        # This is a minimal operation that tests the connection
-                        test_result = await proxy._loop.run_in_executor(
-                            proxy._exe,
-                            lambda: proxy.s3_client.list_objects_v2(
-                                Bucket=proxy.bucket_name,
-                                Prefix=proxy.upload_prefix,
-                                MaxKeys=1
-                            )
+                        # Try to list a few objects to test S3 connectivity.
+                        # boto3's list_objects_v2 is a blocking call with no
+                        # client-side timeout configured here, so wrap it in
+                        # asyncio.wait_for to ensure the health check cannot
+                        # hang indefinitely (which would starve the executor
+                        # and stall every subsequent health probe).
+                        #
+                        # The timeout is derived from the Config injected
+                        # into HealthService so it is kept strictly below
+                        # the health publish interval and a single slow
+                        # probe can never overlap into the next iteration
+                        # of the publisher loop.
+                        s3_probe_timeout = self._probe_timeout()
+
+                        test_result = await asyncio.wait_for(
+                            proxy._loop.run_in_executor(
+                                proxy._exe,
+                                lambda: proxy.s3_client.list_objects_v2(
+                                    Bucket=proxy.bucket_name,
+                                    Prefix=proxy.upload_prefix,
+                                    MaxKeys=1
+                                )
+                            ),
+                            timeout=s3_probe_timeout,
                         )
-                        
+
                         s3_test = S3TestInfo(
                             connectivity="ok",
                             can_access_bucket=True,
@@ -739,6 +792,18 @@ class HealthService:
                             can_access_bucket=False,
                             bucket_accessible=False
                         )
+                except asyncio.TimeoutError:
+                    self.logger.warning(
+                        "S3 list_objects_v2 health probe timed out after %.2fs "
+                        "(kept below health publish interval to avoid overlap)",
+                        s3_probe_timeout,
+                    )
+                    s3_test = S3TestInfo(
+                        connectivity="timeout",
+                        can_access_bucket=False,
+                        bucket_accessible=False,
+                        error=f"S3 list_objects_v2 timed out after {s3_probe_timeout:.2f}s"
+                    )
                 except Exception as e:
                     s3_test = S3TestInfo(
                         connectivity="error",
@@ -880,11 +945,24 @@ class HealthService:
 _health_service: Optional[HealthService] = None
 
 
-def get_health_service(logger: Optional[logging.Logger] = None) -> HealthService:
-    """Get or create the global health service instance."""
+def get_health_service(
+    logger: Optional[logging.Logger] = None,
+    config: Optional[Any] = None,
+) -> HealthService:
+    """Get or create the global health service singleton.
+
+    On subsequent calls, ``logger`` and ``config`` (if provided) update the
+    existing singleton in place so callers can lazily attach them after
+    construction.
+    """
     global _health_service
     if _health_service is None:
-        _health_service = HealthService(logger)
+        _health_service = HealthService(logger, config)
+    else:
+        if logger is not None:
+            _health_service.logger = logger
+        if config is not None:
+            _health_service.config = config
     return _health_service
 
 
@@ -895,3 +973,12 @@ def set_health_service_logger(logger: logging.Logger) -> None:
         _health_service = HealthService(logger)
     else:
         _health_service.logger = logger
+
+
+def set_health_service_config(config: Any) -> None:
+    """Set the Config used by the global health service singleton."""
+    global _health_service
+    if _health_service is None:
+        _health_service = HealthService(config=config)
+    else:
+        _health_service.config = config

--- a/src/petal_app_manager/main.py
+++ b/src/petal_app_manager/main.py
@@ -136,6 +136,7 @@ def build_app() -> FastAPI:
                         test_topic=Config.TEST_TOPIC,
                         command_web_topic=Config.COMMAND_WEB_TOPIC,
                         health_check_interval=Config.MQTT_HEALTH_CHECK_INTERVAL,
+                        health_probe_timeout_s=Config.MQTT_HEALTH_PROBE_TIMEOUT_S,
                     )
                 elif proxy_name == "cloud":
                     proxies["cloud"] = CloudDBProxy(

--- a/src/petal_app_manager/main.py
+++ b/src/petal_app_manager/main.py
@@ -213,7 +213,7 @@ def build_app() -> FastAPI:
         
         # Import the unified health service
         from .health_service import get_health_service
-        health_service = get_health_service(logger)
+        health_service = get_health_service(logger, Config)
         
         # Get petal names from config
         startup_petal_names = list(proxies_config.get("startup_petals") or [])
@@ -253,8 +253,9 @@ def build_app() -> FastAPI:
         nonlocal health_publisher_task
         
         # Step 0: Initialize health service with logger
-        from .health_service import set_health_service_logger
+        from .health_service import set_health_service_logger, set_health_service_config
         set_health_service_logger(logger)
+        set_health_service_config(Config)
         
         # Step 1: Start OrganizationManager first
         logger.info("Starting OrganizationManager...")

--- a/src/petal_app_manager/proxies/external.py
+++ b/src/petal_app_manager/proxies/external.py
@@ -610,6 +610,15 @@ class MavLinkExternalProxy(ExternalProxy):
         self._exe = ThreadPoolExecutor(max_workers=1, thread_name_prefix="MavLinkExternalProxy")
         self.connected = False
         self._last_heartbeat_time = time.time()
+        # Tracks ONLY heartbeats originating from the autopilot
+        # (MAV_COMP_ID_AUTOPILOT1, autopilot != INVALID, type != GCS).
+        # Used by the reboot-confirmation logic so that heartbeats from
+        # routers / companion components / our own echoed heartbeat do not
+        # mask a real autopilot drop during reboot.
+        self._last_autopilot_heartbeat_time: float | None = None
+        # Cached source IDs of the autopilot, learned from heartbeats.
+        self._autopilot_system_id: int | None = None
+        self._autopilot_component_id: int | None = None
         self.leaf_fc_connected = False
         self._last_leaf_fc_heartbeat_time = time.time()
         self._connection_check_interval = 5.0  # Check connection every 5 seconds
@@ -901,8 +910,40 @@ class MavLinkExternalProxy(ExternalProxy):
         return False
 
     async def _on_heartbeat_received(self, msg):
-        """Handler for incoming heartbeat messages to track connection health."""
-        self._last_heartbeat_time = time.time()
+        """Handler for incoming heartbeat messages to track connection health.
+
+        Updates two timestamps:
+          * ``_last_heartbeat_time`` — any HEARTBEAT (used for the generic
+            connection monitor).
+          * ``_last_autopilot_heartbeat_time`` — only HEARTBEATs originating
+            from the autopilot itself (component == MAV_COMP_ID_AUTOPILOT1,
+            non-INVALID autopilot field, non-GCS type). This is what the
+            reboot-confirmation logic uses to detect a real PX4 reboot,
+            since routers / companion computers / echoed heartbeats from
+            this proxy itself would otherwise prevent a "drop" from ever
+            being observed.
+        """
+        now = time.time()
+        self._last_heartbeat_time = now
+
+        try:
+            src_sys = msg.get_srcSystem()
+            src_comp = msg.get_srcComponent()
+            ap_field = getattr(msg, "autopilot", mavutil.mavlink.MAV_AUTOPILOT_INVALID)
+            type_field = getattr(msg, "type", None)
+            mav_type_gcs = getattr(mavutil.mavlink, "MAV_TYPE_GCS", 6)
+            if (
+                src_comp == mavutil.mavlink.MAV_COMP_ID_AUTOPILOT1
+                and ap_field != mavutil.mavlink.MAV_AUTOPILOT_INVALID
+                and type_field != mav_type_gcs
+            ):
+                self._last_autopilot_heartbeat_time = now
+                self._autopilot_system_id = src_sys
+                self._autopilot_component_id = src_comp
+        except Exception:
+            # Never let heartbeat bookkeeping break the receive loop.
+            pass
+
         if not self.connected:
             self.connected = True
             self._log.info("MAVLink connection re-established")
@@ -1271,6 +1312,7 @@ class MavLinkExternalProxy(ExternalProxy):
         self,
         reboot_autopilot: bool = True,
         reboot_onboard_computer: bool = False,
+        target_component: int | None = None,
     ) -> mavutil.mavlink.MAVLink_command_long_message:
         """
         Build a MAVLink command to reboot the autopilot and/or onboard computer.
@@ -1281,6 +1323,13 @@ class MavLinkExternalProxy(ExternalProxy):
             If True, reboot the autopilot (PX4/ArduPilot). Default is True.
         reboot_onboard_computer : bool
             If True, reboot the onboard computer. Default is False.
+        target_component : int, optional
+            MAVLink component ID to address. Defaults to
+            ``MAV_COMP_ID_AUTOPILOT1`` (1) — required for PX4 to act on
+            ``param1``. Falling back to ``master.target_component`` is
+            unsafe because pymavlink's ``wait_heartbeat()`` may have
+            locked onto a router / companion component (e.g. 191/194)
+            whose component will silently drop the reboot command.
 
         Returns
         -------
@@ -1295,14 +1344,31 @@ class MavLinkExternalProxy(ExternalProxy):
         if not self.master or not self.connected:
             raise RuntimeError("MAVLink connection not established")
 
-        # param1: 1=reboot autopilot, 0=do nothing
+        # param1: 1=reboot autopilot, 0=do nothing  (REBOOT_SHUTDOWN_ACTION)
         # param2: 1=reboot onboard computer, 0=do nothing
         param1 = 1.0 if reboot_autopilot else 0.0
         param2 = 1.0 if reboot_onboard_computer else 0.0
 
+        # Prefer the AP component we discovered from a real autopilot HB.
+        # Otherwise default to the canonical MAV_COMP_ID_AUTOPILOT1 (1).
+        if target_component is None:
+            target_component = (
+                self._autopilot_component_id
+                if self._autopilot_component_id is not None
+                else mavutil.mavlink.MAV_COMP_ID_AUTOPILOT1
+            )
+
+        # Use the autopilot system ID we observed from a real autopilot HB
+        # (falling back to master.target_system if we never saw one yet).
+        target_system = (
+            self._autopilot_system_id
+            if self._autopilot_system_id is not None
+            else self.master.target_system
+        )
+
         return self.master.mav.command_long_encode(
-            self.master.target_system,
-            self.master.target_component,
+            target_system,
+            target_component,
             mavutil.mavlink.MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN,
             0,       # confirmation
             param1,  # param1: reboot autopilot
@@ -1931,6 +1997,8 @@ class MavLinkExternalProxy(ExternalProxy):
         hb_return_window_s: float = 30.0,
         hb_poll_interval_s: float = 0.05,
         sitl_mode: bool = False,
+        max_send_attempts: int = 3,
+        retry_delay_s: float = 0.5,
     ) -> RebootAutopilotResponse:
         """
         Send a reboot command and confirm success via heartbeat drop + return.
@@ -1938,22 +2006,28 @@ class MavLinkExternalProxy(ExternalProxy):
         Unlike :meth:`reboot_autopilot`, heartbeat confirmation is the
         **primary** verification method, not a fallback.  The flow is:
 
-        1. Send MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN and wait for COMMAND_ACK.
-           - If the ACK is a rejection, return immediately with failure.
-           - If the ACK is accepted *or* times out, proceed to step 2.
-        2. Wait for heartbeat to **drop** (gap ≥ ``hb_drop_gap_s`` within
-           ``hb_drop_window_s``).
-        3. Wait for heartbeat to **return** (new heartbeat after the drop
-           within ``hb_return_window_s``).
-        4. Return success only when heartbeat returns, confirming the
-           autopilot has rebooted and is alive again.
+        1. Send MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN (targeted at
+           ``MAV_COMP_ID_AUTOPILOT1``) up to ``max_send_attempts`` times,
+           waiting up to ``ack_timeout`` for a COMMAND_ACK on each attempt.
+           - If any ACK is a rejection, return immediately with failure.
+           - If an ACK is ACCEPTED *or* every attempt times out, proceed
+             to step 2.
+        2. Wait for the **autopilot's own** heartbeat to drop (gap
+           ≥ ``hb_drop_gap_s`` within ``hb_drop_window_s``). Heartbeats
+           from routers / companion components are ignored — only
+           heartbeats with ``srcComponent == MAV_COMP_ID_AUTOPILOT1``
+           and ``autopilot != MAV_AUTOPILOT_INVALID`` count.
+        3. Wait for the autopilot heartbeat to return after the drop
+           within ``hb_return_window_s``.
+        4. Return success only when the autopilot heartbeat returns,
+           confirming PX4 has rebooted and is alive again.
 
         Parameters
         ----------
         reboot_onboard_computer : bool
             If True, also reboot the onboard computer.
         ack_timeout : float
-            Maximum time (s) to wait for COMMAND_ACK.
+            Maximum time (s) to wait for COMMAND_ACK on each send attempt.
         hb_drop_window_s : float
             Time window (s) to detect heartbeat drop after command.
         hb_drop_gap_s : float
@@ -1967,6 +2041,12 @@ class MavLinkExternalProxy(ExternalProxy):
             immediately.  This allows SITL testing where the user manually
             kills and restarts the ``px4_sitl`` process to trigger the
             heartbeat drop + return cycle.
+        max_send_attempts : int
+            How many times to (re)send the reboot command if no ACK is
+            received. UDP transport can drop the single datagram and PX4
+            firmware may also miss the first command shortly after boot.
+        retry_delay_s : float
+            Delay between resend attempts (only used if no ACK arrived).
 
         Returns
         -------
@@ -1974,23 +2054,6 @@ class MavLinkExternalProxy(ExternalProxy):
         """
         if not self.connected:
             raise RuntimeError("MAVLink connection not established")
-
-        # ── Step 1: Send reboot command and attempt to get ACK ────────────
-        cmd = self.build_reboot_command(
-            reboot_autopilot=True,
-            reboot_onboard_computer=reboot_onboard_computer,
-        )
-
-        result = {"ack_received": False, "result": None}
-
-        def _collector(pkt) -> bool:
-            if pkt.get_type() != "COMMAND_ACK":
-                return False
-            if pkt.command == mavutil.mavlink.MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
-                result["ack_received"] = True
-                result["result"] = pkt.result
-                return True
-            return False
 
         COMMAND_ACK_ID = str(mavutil.mavlink.MAVLINK_MSG_ID_COMMAND_ACK)
 
@@ -2013,65 +2076,121 @@ class MavLinkExternalProxy(ExternalProxy):
             getattr(mavutil.mavlink, "MAV_RESULT_CANCELLED", -999): "CANCELLED",
         }
 
+        # ── Step 1: Send reboot command (with retries) and try to get ACK ──
         ack_received = False
         ack_val = None
 
-        try:
-            await self.send_and_wait(
-                match_key=COMMAND_ACK_ID,
-                request_msg=cmd,
-                collector=_collector,
-                timeout=ack_timeout,
-            )
-        except TimeoutError:
-            self._log.warning(
-                "Reboot command sent but no ACK received; proceeding to heartbeat confirmation..."
+        # Capture the autopilot heartbeat baseline *before* sending so the
+        # drop detector measures from a known-fresh moment, not from some
+        # stale value left over from earlier in the session.
+        send_baseline_ts = self._last_autopilot_heartbeat_time
+
+        for attempt in range(1, max_send_attempts + 1):
+            cmd = self.build_reboot_command(
+                reboot_autopilot=True,
+                reboot_onboard_computer=reboot_onboard_computer,
             )
 
-        if result["ack_received"]:
-            ack_received = True
-            ack_val = result["result"]
-            ack_name = _ACK_NAME.get(ack_val, f"UNKNOWN({ack_val})")
+            self._log.info(
+                "Sending PX4 reboot (MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN) "
+                "attempt %d/%d -> sys=%d comp=%d",
+                attempt, max_send_attempts,
+                cmd.target_system, cmd.target_component,
+            )
 
-            # If ACK is a rejection, fail immediately — no point waiting for heartbeat
-            # Exception: in SITL mode, DENIED is expected (simulator cannot reboot)
-            # so we skip the failure and proceed to heartbeat confirmation,
-            # allowing the user to manually kill/restart px4_sitl.
-            if ack_val != mavutil.mavlink.MAV_RESULT_ACCEPTED:
-                if sitl_mode and ack_val == mavutil.mavlink.MAV_RESULT_DENIED:
-                    self._log.warning(
-                        f"SITL_MODE: Reboot ACK was DENIED (expected for SITL). "
-                        f"Proceeding to heartbeat confirmation — manually kill and "
-                        f"restart px4_sitl within {hb_drop_window_s}s to trigger "
-                        f"heartbeat drop..."
-                    )
-                else:
+            attempt_result = {"ack_received": False, "result": None}
+
+            def _collector(pkt, _r=attempt_result) -> bool:
+                if pkt.get_type() != "COMMAND_ACK":
+                    return False
+                if pkt.command == mavutil.mavlink.MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
+                    _r["ack_received"] = True
+                    _r["result"] = pkt.result
+                    return True
+                return False
+
+            try:
+                await self.send_and_wait(
+                    match_key=COMMAND_ACK_ID,
+                    request_msg=cmd,
+                    collector=_collector,
+                    timeout=ack_timeout,
+                )
+            except TimeoutError:
+                self._log.warning(
+                    "No COMMAND_ACK for reboot on attempt %d/%d (timeout=%.1fs).",
+                    attempt, max_send_attempts, ack_timeout,
+                )
+
+            if attempt_result["ack_received"]:
+                ack_received = True
+                ack_val = attempt_result["result"]
+                ack_name = _ACK_NAME.get(ack_val, f"UNKNOWN({ack_val})")
+                self._log.info("Reboot ACK received: %s (%s)", ack_val, ack_name)
+
+                if ack_val != mavutil.mavlink.MAV_RESULT_ACCEPTED:
+                    # In SITL the simulator can't actually reboot itself,
+                    # so DENIED is expected; let the user kill/restart it.
+                    if sitl_mode and ack_val == mavutil.mavlink.MAV_RESULT_DENIED:
+                        self._log.warning(
+                            "SITL_MODE: Reboot ACK was DENIED (expected for SITL). "
+                            "Proceeding to heartbeat confirmation — manually kill/restart "
+                            "px4_sitl within %.1fs to trigger heartbeat drop...",
+                            hb_drop_window_s,
+                        )
+                        break
                     status = _ACK_TO_STATUS.get(ack_val, RebootStatusCode.FAIL_ACK_UNKNOWN)
-                    self._log.warning(f"Reboot command rejected with result: {ack_val} ({ack_name})")
+                    self._log.warning(
+                        "Reboot command rejected with result: %s (%s)", ack_val, ack_name,
+                    )
                     return RebootAutopilotResponse(
                         success=False,
                         status_code=status,
                         reason=f"Autopilot rejected the reboot command: {ack_name}.",
                         ack_result=ack_val,
                     )
-            else:
-                self._log.info("Reboot command accepted by autopilot, proceeding to heartbeat confirmation...")
+                # ACCEPTED — break out of retry loop
+                break
+
+            # No ACK on this attempt; back off briefly before resending.
+            if attempt < max_send_attempts:
+                await asyncio.sleep(retry_delay_s)
+
+        if not ack_received:
+            self._log.warning(
+                "Reboot command sent %d time(s) with no COMMAND_ACK; "
+                "falling back to heartbeat-based confirmation.",
+                max_send_attempts,
+            )
 
         # ── Step 2: Heartbeat drop confirmation (primary check) ───────────
-        last_hb = getattr(self, "_last_heartbeat_time", None)
-        if last_hb is None:
-            self._log.warning("No heartbeat timestamp available; cannot confirm reboot via heartbeat.")
+        # We confirm reboot using the autopilot's OWN heartbeat. Heartbeats
+        # from a mavlink-router, companion computer, GCS or our own echoed
+        # heartbeat are ignored, otherwise they would mask a real drop and
+        # we'd see the symptom from the bug report:
+        #   "Heartbeat did not drop within 15.0s window".
+        last_ap_hb = self._last_autopilot_heartbeat_time
+        if last_ap_hb is None:
+            self._log.warning(
+                "No autopilot heartbeat has been observed yet "
+                "(_last_autopilot_heartbeat_time is None). "
+                "Cannot confirm reboot via heartbeat — has the autopilot "
+                "ever connected at component MAV_COMP_ID_AUTOPILOT1 (1)?"
+            )
             return RebootAutopilotResponse(
                 success=False,
                 status_code=RebootStatusCode.FAIL_NO_HEARTBEAT_TRACKING,
-                reason="Heartbeat tracking is unavailable (_last_heartbeat_time is None). Cannot confirm reboot.",
+                reason=(
+                    "Autopilot heartbeat tracking unavailable: no HEARTBEAT "
+                    "from MAV_COMP_ID_AUTOPILOT1 has ever been observed."
+                ),
                 ack_result=ack_val,
             )
 
         async def _wait_for_heartbeat_drop() -> bool:
             deadline = time.time() + hb_drop_window_s
             while time.time() < deadline:
-                last = getattr(self, "_last_heartbeat_time", None)
+                last = self._last_autopilot_heartbeat_time
                 if last is not None and (time.time() - last) >= hb_drop_gap_s:
                     return True
                 await asyncio.sleep(hb_poll_interval_s)
@@ -2079,25 +2198,35 @@ class MavLinkExternalProxy(ExternalProxy):
 
         dropped = await _wait_for_heartbeat_drop()
         if not dropped:
-            self._log.warning("Heartbeat did not drop within the expected window; reboot not confirmed.")
+            now = time.time()
+            last = self._last_autopilot_heartbeat_time
+            age = (now - last) if last is not None else float("inf")
+            self._log.warning(
+                "Autopilot heartbeat did not drop within %.1fs window "
+                "(gap threshold: %.1fs, last AP HB age: %.2fs, "
+                "AP sys=%s comp=%s, baseline_ts=%s). Reboot not confirmed.",
+                hb_drop_window_s, hb_drop_gap_s, age,
+                self._autopilot_system_id, self._autopilot_component_id,
+                send_baseline_ts,
+            )
             return RebootAutopilotResponse(
                 success=False,
                 status_code=RebootStatusCode.FAIL_REBOOT_NOT_CONFIRMED_NO_HB_DROP,
                 reason=(
-                    f"Heartbeat did not drop within {hb_drop_window_s}s window "
-                    f"(gap threshold: {hb_drop_gap_s}s). Reboot not confirmed."
+                    f"Autopilot heartbeat did not drop within {hb_drop_window_s}s "
+                    f"window (gap threshold: {hb_drop_gap_s}s). Reboot not confirmed."
                 ),
                 ack_result=ack_val,
             )
 
-        drop_mark = getattr(self, "_last_heartbeat_time", last_hb) or last_hb
-        self._log.info("Heartbeat drop detected, waiting for heartbeat to return...")
+        drop_mark = self._last_autopilot_heartbeat_time or last_ap_hb
+        self._log.info("Autopilot heartbeat drop detected, waiting for heartbeat to return...")
 
         # ── Step 3: Heartbeat return confirmation ─────────────────────────
         async def _wait_for_heartbeat_return(since_ts: float) -> bool:
             deadline = time.time() + hb_return_window_s
             while time.time() < deadline:
-                last = getattr(self, "_last_heartbeat_time", None)
+                last = self._last_autopilot_heartbeat_time
                 if last is not None and last > since_ts:
                     return True
                 await asyncio.sleep(hb_poll_interval_s)
@@ -2105,32 +2234,32 @@ class MavLinkExternalProxy(ExternalProxy):
 
         returned = await _wait_for_heartbeat_return(since_ts=drop_mark)
         if not returned:
-            self._log.warning("Heartbeat dropped but did not return; reboot not confirmed.")
+            self._log.warning("Autopilot heartbeat dropped but did not return; reboot not confirmed.")
             return RebootAutopilotResponse(
                 success=False,
                 status_code=RebootStatusCode.FAIL_REBOOT_NOT_CONFIRMED_HB_NO_RETURN,
                 reason=(
-                    f"Heartbeat drop observed but heartbeat did not return within "
-                    f"{hb_return_window_s}s. Autopilot may still be rebooting."
+                    f"Heartbeat drop observed but autopilot heartbeat did not return "
+                    f"within {hb_return_window_s}s. Autopilot may still be rebooting."
                 ),
                 ack_result=ack_val,
             )
 
         # ── Step 4: Confirmed ─────────────────────────────────────────────
         if ack_received:
-            self._log.info("Reboot confirmed: ACK accepted + heartbeat drop + return.")
+            self._log.info("Reboot confirmed: ACK accepted + autopilot heartbeat drop + return.")
             return RebootAutopilotResponse(
                 success=True,
                 status_code=RebootStatusCode.OK_ACK_ACCEPTED_HB_CONFIRMED,
-                reason="Reboot confirmed: COMMAND_ACK accepted and heartbeat drop + return observed.",
+                reason="Reboot confirmed: COMMAND_ACK accepted and autopilot heartbeat drop + return observed.",
                 ack_result=ack_val,
             )
         else:
-            self._log.info("Reboot confirmed via heartbeat drop + return (no ACK received).")
+            self._log.info("Reboot confirmed via autopilot heartbeat drop + return (no ACK received).")
             return RebootAutopilotResponse(
                 success=True,
                 status_code=RebootStatusCode.OK_HB_CONFIRMED_NO_ACK,
-                reason="Reboot confirmed via heartbeat drop + return (no COMMAND_ACK received).",
+                reason="Reboot confirmed via autopilot heartbeat drop + return (no COMMAND_ACK received).",
                 ack_result=None,
             )
 

--- a/src/petal_app_manager/proxies/external.py
+++ b/src/petal_app_manager/proxies/external.py
@@ -2009,9 +2009,11 @@ class MavLinkExternalProxy(ExternalProxy):
         1. Send MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN (targeted at
            ``MAV_COMP_ID_AUTOPILOT1``) up to ``max_send_attempts`` times,
            waiting up to ``ack_timeout`` for a COMMAND_ACK on each attempt.
+
            - If any ACK is a rejection, return immediately with failure.
            - If an ACK is ACCEPTED *or* every attempt times out, proceed
              to step 2.
+
         2. Wait for the **autopilot's own** heartbeat to drop (gap
            ≥ ``hb_drop_gap_s`` within ``hb_drop_window_s``). Heartbeats
            from routers / companion components are ignored — only

--- a/src/petal_app_manager/proxies/mqtt.py
+++ b/src/petal_app_manager/proxies/mqtt.py
@@ -66,7 +66,8 @@ class MQTTProxy(BaseProxy):
         response_topic: str = "response",
         test_topic: str = "command",
         command_web_topic: str = "command/web",
-        health_check_interval: float = 10.0
+        health_check_interval: float = 10.0,
+        health_probe_timeout_s: float = 2.0,
     ):
         self.ts_client_host = ts_client_host
         self.ts_client_port = ts_client_port
@@ -107,6 +108,7 @@ class MQTTProxy(BaseProxy):
         # Health monitoring
         self._health_monitor_task = None
         self._health_check_interval = health_check_interval
+        self._health_probe_timeout_s = health_probe_timeout_s
 
         self._loop = None
         self._exe = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="MQTTProxy")
@@ -142,23 +144,58 @@ class MQTTProxy(BaseProxy):
             
             if is_healthy:
                 self.log.info("TypeScript MQTT client is healthy")
-                # Mark as connected since TypeScript client is healthy
-                self.is_connected = True
-                
-                # Try to subscribe to default device topics if organization ID is available
+                # Try to subscribe to default device topics if organization ID is available.
+                # NOTE: ``/health`` returning 200 does NOT guarantee the TS
+                # sidecar's broker connection is established — it can return
+                # 200 a few hundred ms before the AWS-IoT MQTT session is
+                # actually up, in which case our /subscribe RPC succeeds at
+                # the HTTP layer but the broker silently drops the
+                # subscription.  We therefore mark ``is_connected`` only
+                # once :meth:`_ensure_subscriptions` reports convergence;
+                # if the first pass doesn't converge, the health monitor
+                # below will keep retrying every health-check interval
+                # until the TS sidecar fully accepts every expected topic.
                 organization_id = self._get_organization_id()
                 if organization_id:
                     self.log.info("Organization ID available, subscribing to device topics...")
                     try:
                         from .. import Config
-                        await asyncio.wait_for(self._subscribe_to_device_topics(), timeout=Config.MQTT_SUBSCRIBE_TIMEOUT)
-                        self.log.info("Successfully subscribed to device topics")
+                        await asyncio.wait_for(
+                            self._ensure_subscriptions(),
+                            timeout=Config.MQTT_SUBSCRIBE_TIMEOUT,
+                        )
                     except asyncio.TimeoutError:
-                        self.log.warning("Timeout subscribing to device topics during startup")
+                        self.log.warning(
+                            "Timeout subscribing to device topics during startup; "
+                            "health monitor will keep retrying."
+                        )
                     except Exception as e:
-                        self.log.error(f"Failed to subscribe to device topics: {e}")
+                        self.log.error(
+                            f"Failed to subscribe to device topics during startup: {e}; "
+                            f"health monitor will keep retrying."
+                        )
+                    # Reflect actual subscription state, not optimistic.
+                    self.is_connected = (
+                        len(
+                            [t for t in self._expected_device_topics()
+                             if t not in self.subscribed_topics]
+                        ) == 0
+                    )
+                    if self.is_connected:
+                        self.log.info("Successfully subscribed to all device topics")
+                    else:
+                        self.log.warning(
+                            "Initial subscribe did not fully converge "
+                            "(TS sidecar may still be connecting to broker); "
+                            "health monitor will keep retrying every %.1fs.",
+                            self._health_check_interval,
+                        )
                 else:
-                    self.log.info("Organization ID not available, skipping device topic subscription")
+                    self.log.info(
+                        "Organization ID not available; deferring device topic "
+                        "subscription. Health monitor will subscribe once org_id arrives."
+                    )
+                    self.is_connected = False
             else:
                 self.log.warning("TypeScript MQTT client is not accessible - will monitor and retry")
                 self.is_connected = False
@@ -189,7 +226,7 @@ class MQTTProxy(BaseProxy):
         # clear all registered handlers
         self._handlers.clear()
 
-        for topic in self.subscribed_topics:
+        for topic in list(self.subscribed_topics):
             await self._unsubscribe_from_topic(topic)
 
         self.subscribed_topics.clear()
@@ -354,75 +391,158 @@ class MQTTProxy(BaseProxy):
             self.log.error(f"Error in callback for topic {topic}: {e}")
 
     # ------ TypeScript Client Communication ------ #
-    
+
     async def _check_ts_client_health(self) -> bool:
-        """Check if TypeScript MQTT client is healthy."""
+        """Check if TypeScript MQTT client is healthy.
+
+        Uses the per-instance ``_health_probe_timeout_s`` (configured via
+        ``Config.MQTT_HEALTH_PROBE_TIMEOUT_S``) so a hung sidecar cannot
+        block the single MQTTProxy executor thread for the full
+        ``request_timeout`` (30 s) and starve subscribe/publish RPCs.
+        """
         try:
             response = await self._loop.run_in_executor(
                 self._exe,
-                lambda: requests.get(f"{self.ts_base_url}/health", timeout=self.request_timeout)
+                lambda: requests.get(
+                    f"{self.ts_base_url}/health",
+                    timeout=self._health_probe_timeout_s,
+                ),
             )
             return response.status_code == 200
         except Exception as e:
             self.log.debug(f"TypeScript client unreachable: {type(e).__name__}")
             return False
 
+    def _expected_device_topics(self) -> List[str]:
+        """Return the fully-qualified set of device topics this proxy
+        expects to be subscribed to whenever TS+org are both available."""
+        base_topic = self._get_base_topic()
+        if not base_topic:
+            return []
+        return [
+            f"{base_topic}/{self.command_edge_topic}",
+            f"{base_topic}/{self.response_topic}",
+            f"{base_topic}/{self.test_topic}",
+        ]
+
+    async def _ensure_subscriptions(self) -> bool:
+        """Re-subscribe to any expected device topics that aren't already in
+        ``self.subscribed_topics``.  Returns True iff every expected topic
+        is subscribed at the end of the call.
+
+        This is the single place that drives convergence between
+        "what we want" (``_expected_device_topics``) and "what the TS
+        sidecar has accepted" (``self.subscribed_topics``).  It is
+        invoked on every healthy poll of the health monitor so that a
+        startup race (TS ``/health`` returns 200 before its broker
+        connection finishes — silently dropping our subscribe RPC), a
+        late-arriving org_id, or a silent broker flap all self-heal.
+        """
+        expected = self._expected_device_topics()
+        if not expected:
+            # No org_id / device_id yet; nothing to do.
+            return False
+
+        base_topic = self._get_base_topic()
+        missing = [t for t in expected if t not in self.subscribed_topics]
+        if not missing:
+            return True
+
+        self.log.info(
+            "Re-subscribing to %d/%d missing device topics...",
+            len(missing), len(expected),
+        )
+        for topic in missing:
+            relative = topic[len(base_topic) + 1:] if topic.startswith(base_topic + "/") else topic
+            ok = await self._subscribe_to_topic(relative)
+            if not ok:
+                self.log.warning(
+                    "Subscribe failed for %s; will retry on next health poll.",
+                    topic,
+                )
+
+        # Register the default device-topic handler once (idempotent),
+        # but only after the command_edge topic is actually subscribed —
+        # ``register_handler`` refuses to attach to an unsubscribed
+        # topic.  We guard against duplicate registrations across
+        # reconnects by checking the handler list first.
+        cmd_edge_full = f"{base_topic}/{self.command_edge_topic}"
+        if cmd_edge_full in self.subscribed_topics:
+            existing = self._handlers.get(cmd_edge_full, [])
+            already_registered = any(
+                h.get("callback") is self._default_message_handler for h in existing
+            )
+            if not already_registered:
+                self.register_handler(self._default_message_handler)
+
+        # Re-evaluate after attempts.
+        still_missing = [t for t in expected if t not in self.subscribed_topics]
+        if still_missing:
+            self.log.warning(
+                "After re-subscribe pass, %d/%d device topics still missing; "
+                "will retry on next health poll.",
+                len(still_missing), len(expected),
+            )
+            return False
+
+        self.log.info("All device topic subscriptions converged.")
+        return True
+
     async def _health_monitor_loop(self):
-        """Background task to monitor TypeScript client health and restore device topic subscriptions."""
+        """Periodically poll the TypeScript MQTT sidecar's health and
+        keep our device-topic subscriptions converged with what the
+        sidecar accepts.
+
+        On every iteration:
+          * If the sidecar is unhealthy, mark disconnected and clear our
+            local subscription view (so the next recovery re-subscribes
+            to every expected topic instead of believing it's still
+            subscribed).
+          * If the sidecar is healthy, drive
+            :meth:`_ensure_subscriptions` to convergence — this handles
+            the startup race where ``/health`` is 200 but the sidecar's
+            broker connection isn't ready yet (silently dropped subs),
+            late-arriving org_id, and any broker flap that doesn't
+            also flip ``/health`` to non-200.
+        """
         self.log.info("Health monitor started")
-        last_health_status = self.is_connected
-        
+
         while not self._shutdown_flag:
             try:
                 await asyncio.sleep(self._health_check_interval)
-                
-                # Check TypeScript client health
+
                 is_healthy = await self._check_ts_client_health()
-                
-                # If health status changed
-                if is_healthy != last_health_status:
-                    if is_healthy:
-                        self.log.info("TypeScript client health restored")
-                        # Check if we have organization ID
-                        organization_id = self._get_organization_id()
-                        if organization_id:
-                            # Get expected device topics
-                            expected_topics = [
-                                f"{self._get_base_topic()}/{self.command_edge_topic}",
-                                f"{self._get_base_topic()}/{self.response_topic}",
-                                f"{self._get_base_topic()}/{self.test_topic}"
-                            ]
-                            
-                            # Check which topics are missing
-                            missing_topics = [t for t in expected_topics if t not in self.subscribed_topics]
-                            
-                            if missing_topics:
-                                self.log.info(f"Re-subscribing to {len(missing_topics)} missing device topics...")
-                                for topic in missing_topics:
-                                    # Extract relative topic from full path
-                                    base_topic = self._get_base_topic()
-                                    relative_topic = topic[len(base_topic)+1:] if topic.startswith(base_topic) else topic
-                                    await self._subscribe_to_topic(relative_topic)
-                                self.log.info("Device topic subscriptions restored")
-                            else:
-                                self.log.info("All device topics already subscribed")
-                            
-                            self.is_connected = True
-                        else:
-                            self.log.debug("Health restored but organization ID not available yet")
-                    else:
-                        self.log.warning("TypeScript client health check failed - marking as disconnected")
+
+                if not is_healthy:
+                    if self.is_connected or self.subscribed_topics:
+                        self.log.warning(
+                            "TypeScript client health check failed - marking as disconnected"
+                        )
+                    self.is_connected = False
+                    self.subscribed_topics.clear()
+                    continue
+
+                organization_id = self._get_organization_id()
+                if not organization_id:
+                    # Healthy but org_id not available yet — wait for it.
+                    if self.is_connected:
                         self.is_connected = False
-                    
-                    last_health_status = is_healthy
-                    
+                    self.log.info(
+                        "TS healthy but organization ID not available yet; "
+                        "deferring subscription convergence."
+                    )
+                    continue
+
+                converged = await self._ensure_subscriptions()
+                self.is_connected = converged
+
             except asyncio.CancelledError:
                 self.log.info("Health monitor cancelled")
                 break
             except Exception as e:
                 self.log.error(f"Error in health monitor loop: {e}")
                 # Continue monitoring despite errors
-                
+
         self.log.info("Health monitor stopped")
 
     async def _make_ts_request(self, method: str, endpoint: str, data: Optional[Dict] = None) -> Dict[str, Any]:
@@ -526,11 +646,26 @@ class MQTTProxy(BaseProxy):
             }
             
             result = await self._make_ts_request("POST", "/subscribe", request_data)
-            
+            self.log.info(f"Subscribe request for {topic_subscribe} returned: {result}")
+
+            if not isinstance(result, dict):
+                self.log.error(
+                    f"Failed to subscribe to {topic_subscribe}: "
+                    f"unexpected response type {type(result).__name__}"
+                )
+                return False
+
             if "error" in result:
                 self.log.error(f"Failed to subscribe to {topic_subscribe}: {result['error']}")
                 return False
 
+            if result.get("success") is not True:
+                self.log.warning(
+                    f"Subscribe to {topic_subscribe} did not return success=true "
+                    f"(broker likely not ready yet); will retry on next health poll. "
+                    f"Response: {result}"
+                )
+                return False
 
             self.subscribed_topics.add(topic_subscribe)
 
@@ -543,26 +678,65 @@ class MQTTProxy(BaseProxy):
 
     async def _unsubscribe_from_topic(self, topic: str) -> bool:
         """
-        Unsubscribe from an MQTT topic.
+        Unsubscribe from an MQTT topic on the TypeScript client.
+
+        Accepts either a full topic (``org/<id>/device/<id>/...``) or a
+        relative topic (the base prefix is added automatically).  This
+        keeps backward compatibility with both calling styles.
+
         Args:
-            topic: Topic to unsubscribe from (relative to base topic)
+            topic: Topic to unsubscribe from (full or relative).
         Returns:
-            True if unsubscribed successfully, False otherwise
+            True if the TS client acknowledged the unsubscribe, False otherwise.
         """
+        topic_unsubscribe = topic  # default for the except-block log
         try:
-            # make sure topic just does not have a leading slash
+            # strip a single leading slash if present
             if topic.startswith("/"):
                 topic = topic[1:]
 
-            topic_unsubscribe = f"{self._get_base_topic()}/{topic}"
+            base_topic = self._get_base_topic()
+            if base_topic and topic.startswith(base_topic + "/"):
+                topic_unsubscribe = topic
+            elif base_topic:
+                topic_unsubscribe = f"{base_topic}/{topic}"
+            else:
+                # No base topic available; trust caller-supplied value.
+                topic_unsubscribe = topic
 
-            # Unsubscribe using the subscription ID
-            if topic_unsubscribe in self.subscribed_topics:
-                self.subscribed_topics.remove(topic_unsubscribe)
+            result = await self._make_ts_request(
+                "POST",
+                "/unsubscribe",
+                {"topic": topic_unsubscribe},
+            )
 
+            self.log.info(f"Unsubscribe request for {topic_unsubscribe} returned: {result}")
+
+            if not isinstance(result, dict):
+                self.log.error(
+                    f"Failed to unsubscribe from {topic_unsubscribe}: "
+                    f"unexpected response type {type(result).__name__}"
+                )
+                return False
+
+            if "error" in result:
+                self.log.warning(
+                    f"TS client returned error on unsubscribe of {topic_unsubscribe}: "
+                    f"{result['error']}"
+                )
+                return False
+
+            if result.get("success") is not True:
+                self.log.warning(
+                    f"Unsubscribe of {topic_unsubscribe} did not return success=true; "
+                    f"keeping local subscription. Response: {result}"
+                )
+                return False
+
+            self.subscribed_topics.discard(topic_unsubscribe)
             self.log.info(f"Unsubscribed from topic: {topic_unsubscribe}")
             return True
-            
+
         except Exception as e:
             self.log.error(f"Error unsubscribing from {topic_unsubscribe}: {e}")
             return False
@@ -642,11 +816,25 @@ class MQTTProxy(BaseProxy):
             }
             
             result = await self._make_ts_request("POST", "/publish", request_data)
-            
+
+            if not isinstance(result, dict):
+                self.log.error(
+                    f"Failed to publish message to {topic_publish}: "
+                    f"unexpected response type {type(result).__name__}"
+                )
+                return False
+
             if "error" in result:
                 self.log.error(f"Failed to publish message to {topic_publish}: {result['error']}")
                 return False
-            
+
+            if result.get("success") is not True:
+                self.log.error(
+                    f"Publish to {topic_publish} did not return success=true; "
+                    f"broker likely not ready. Response: {result}"
+                )
+                return False
+
             self.log.debug(f"Published message to topic: {topic_publish}")
             return True
             

--- a/tests/test_mqtt_proxy.py
+++ b/tests/test_mqtt_proxy.py
@@ -51,7 +51,7 @@ async def proxy() -> AsyncGenerator[MQTTProxy, None]:
         # Setup mock responses for MQTT operations
         mock_operation_response = MagicMock()
         mock_operation_response.status_code = 200
-        mock_operation_response.json.return_value = {"status": "success"}
+        mock_operation_response.json.return_value = {"success": True, "status": "success"}
         mock_request.return_value = mock_operation_response
         
         # Store references to mocks for assertions
@@ -94,7 +94,7 @@ async def proxy_no_callbacks() -> AsyncGenerator[MQTTProxy, None]:
         
         mock_operation_response = MagicMock()
         mock_operation_response.status_code = 200
-        mock_operation_response.json.return_value = {"status": "success"}
+        mock_operation_response.json.return_value = {"success": True, "status": "success"}
         mock_request.return_value = mock_operation_response
         
         proxy._mock_get = mock_get
@@ -198,7 +198,7 @@ async def test_missing_organization_id():
             
             # Should succeed - organization_id not required at startup
             await proxy.start()
-            assert proxy.is_connected is True
+            assert proxy.is_connected is False
             await proxy.stop()
 
 
@@ -297,7 +297,7 @@ async def test_publish_message_success(proxy: MQTTProxy):
     # Setup mock response
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"status": "success"}
+    mock_response.json.return_value = {"success": True, "status": "success"}
     
     with patch('requests.request', return_value=mock_response):
         result = await proxy.publish_message(
@@ -346,7 +346,7 @@ async def test_send_command_response(proxy: MQTTProxy):
     # Setup mock response
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"status": "success"}
+    mock_response.json.return_value = {"success": True, "status": "success"}
     
     with patch('requests.request', return_value=mock_response):
         result = await proxy.send_command_response(
@@ -468,7 +468,7 @@ async def test_process_command_message(proxy: MQTTProxy):
     # Setup mock for response publishing
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"status": "success"}
+    mock_response.json.return_value = {"success": True, "status": "success"}
     
     with patch('requests.request', return_value=mock_response):
         command_topic = f"org/{proxy.organization_id}/device/{proxy.device_id}/command"
@@ -569,7 +569,7 @@ async def test_basic_workflow(proxy: MQTTProxy):
     # Setup mock responses
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"status": "success"}
+    mock_response.json.return_value = {"success": True, "status": "success"}
     
     messages_received = []
     
@@ -653,7 +653,7 @@ async def test_concurrent_operations(proxy: MQTTProxy):
     # Setup mock responses
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"status": "success"}
+    mock_response.json.return_value = {"success": True, "status": "success"}
     
     with patch('requests.request', return_value=mock_response):
         # Run multiple publish operations concurrently (all to command/web topic)


### PR DESCRIPTION
This pull request introduces robust timeout handling and improved reliability for health checks and reboot logic, especially around S3, MQTT, and MAVLink autopilot proxies. It also enhances configuration flexibility by allowing timeouts to be set via environment variables and config injection. The reboot confirmation logic is now more precise, targeting only the real autopilot component and supporting retry logic to handle communication issues.

**Health check improvements:**

* Added per-probe timeouts for S3 and MQTT health checks, ensuring that slow probes cannot block the health publisher loop; timeouts are derived from configurable publish intervals and are logged appropriately. [[1]](diffhunk://#diff-be7628d1a3137c3c66275b94abc817529aeb1701698afc20d00ae4d18203aa67L45-R85) [[2]](diffhunk://#diff-be7628d1a3137c3c66275b94abc817529aeb1701698afc20d00ae4d18203aa67L720-R781) [[3]](diffhunk://#diff-be7628d1a3137c3c66275b94abc817529aeb1701698afc20d00ae4d18203aa67R795-R806) [[4]](diffhunk://#diff-be7628d1a3137c3c66275b94abc817529aeb1701698afc20d00ae4d18203aa67L809-R902)
* Refactored the `HealthService` to accept a config object, enabling dynamic adjustment of publish intervals and probe timeouts; updated singleton management to allow logger/config injection after creation. [[1]](diffhunk://#diff-be7628d1a3137c3c66275b94abc817529aeb1701698afc20d00ae4d18203aa67L45-R85) [[2]](diffhunk://#diff-be7628d1a3137c3c66275b94abc817529aeb1701698afc20d00ae4d18203aa67L883-R992) [[3]](diffhunk://#diff-be7628d1a3137c3c66275b94abc817529aeb1701698afc20d00ae4d18203aa67R1003-R1011)

**Configuration enhancements:**

* Introduced `HEALTH_PROBE_TIMEOUT_S` in `MQTTConfig` and propagated it to `RebootConfig` and proxy instantiation, enabling environment-based control of probe timeouts. [[1]](diffhunk://#diff-fe78c15b7b87f9827bde531d8193a30070d681f843be8a078826f689dc0422d5R86) [[2]](diffhunk://#diff-fe78c15b7b87f9827bde531d8193a30070d681f843be8a078826f689dc0422d5R159) [[3]](diffhunk://#diff-4ecd7d29b755c71154de7298ef2ff1ed1abbc0b8d2838fd64c47b130f4db8f1eR139)
* Updated main application logic to inject the config into the health service at startup and on health status publishing. [[1]](diffhunk://#diff-4ecd7d29b755c71154de7298ef2ff1ed1abbc0b8d2838fd64c47b130f4db8f1eL216-R217) [[2]](diffhunk://#diff-4ecd7d29b755c71154de7298ef2ff1ed1abbc0b8d2838fd64c47b130f4db8f1eL256-R259)

**MAVLink/proxy reboot reliability:**

* Enhanced heartbeat tracking in `MavLinkExternalProxy` to distinguish heartbeats from the real autopilot versus other components, improving reboot confirmation accuracy. [[1]](diffhunk://#diff-c2e50a59c46b7e79552b801f6a3eebcbeda4629654319b5a41fab3ac2285b643R613-R621) [[2]](diffhunk://#diff-c2e50a59c46b7e79552b801f6a3eebcbeda4629654319b5a41fab3ac2285b643L904-R946)
* Updated reboot command construction to target the discovered autopilot component/system IDs, avoiding issues with routers or companion components ignoring commands. [[1]](diffhunk://#diff-c2e50a59c46b7e79552b801f6a3eebcbeda4629654319b5a41fab3ac2285b643R1315) [[2]](diffhunk://#diff-c2e50a59c46b7e79552b801f6a3eebcbeda4629654319b5a41fab3ac2285b643R1326-R1332) [[3]](diffhunk://#diff-c2e50a59c46b7e79552b801f6a3eebcbeda4629654319b5a41fab3ac2285b643L1298-R1371)
* Improved reboot confirmation logic to retry sending reboot commands if no ACK is received, document all parameters, and clarify that only real autopilot heartbeats are used for confirmation. [[1]](diffhunk://#diff-c2e50a59c46b7e79552b801f6a3eebcbeda4629654319b5a41fab3ac2285b643R2000-R2030) [[2]](diffhunk://#diff-c2e50a59c46b7e79552b801f6a3eebcbeda4629654319b5a41fab3ac2285b643R2044-R2049)

These changes collectively make the health monitoring and reboot processes more reliable, configurable, and robust against edge cases and communication failures.