### PR TITLE
Bump version to 0.2.7 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "petal-app-manager"
-version = "0.2.5"
+version = "0.2.7"
 description = "A FastAPI interface for loading, managing and running Droneleaf Petal applications"
 authors = [
     {name = "Khalil Al Handawi", email = "khalil.alhandawi@droneleaf.io"},


### PR DESCRIPTION
This pull request makes a minor update to the project metadata, specifically incrementing the version number in the `pyproject.toml` file to `0.2.7`.